### PR TITLE
Allows for styling tabs with data-state-"active"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import plugin from "tailwindcss/plugin";
 
 const dataAttributes = {
-  state: ["open", "close"],
+  state: ["open", "close", "active"],
   side: ["top", "bottom", "left", "right"],
   orientation: ["horizontal", "vertical"],
 };
@@ -25,12 +25,14 @@ export = plugin.withOptions((options) => ({ addUtilities, addVariant, e }) => {
   // `--radix-context-menu-content-transform-origin`,
   // `--radix-popover-content-transform-origin`,
   // `--radix-tooltip-content-transform-origin`,
+  // `--radix-tabs-content-transform-origin`,
   const transformOrigins = [
     "dropdown-menu",
     "hover-card",
     "context-menu",
     "popover",
     "tooltip",
+    "tabs",
   ];
 
   transformOrigins.forEach((transformOrigin) => {


### PR DESCRIPTION
Radix-Ui's Tabs component uses a data-state-active rather than data-state-open. This pr includes the active state and will allow for styling an active tab.