### PR TITLE
Fix typo in `dataAttributes` for `closed` state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import plugin from "tailwindcss/plugin";
 
 const dataAttributes = {
-  state: ["open", "close", "active", "inactive", "on", "off"],
+  state: ["open", "closed", "active", "inactive", "on", "off"],
   side: ["top", "bottom", "left", "right"],
   orientation: ["horizontal", "vertical"],
 };


### PR DESCRIPTION
Radix uses `data-state="closed"` and not `close`. This PR fixes that.

Example, the [Accordion](https://www.radix-ui.com/docs/primitives/components/accordion#animating-content-size) docs:

<img width="615" alt="Screenshot 2021-12-18 at 19 49 29" src="https://user-images.githubusercontent.com/5436545/146652604-fdd0d31a-b59e-45c0-9706-1a502191e5e4.png">

