### PR TITLE
add h-*/w-* size utilities of the content when it opens/closes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This plugin also generates the following `origin-*` utilities to transform from 
 }
 ```
 
-### Animating content size-content
+### Animating content size
 
 This plugin also generates the following `h-*` and `w-*` utilities to animate the size of the content when it opens/closes.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This plugin also generates the following `origin-*` utilities to transform from 
 }
 ```
 
-### Animating content size
+### Animating content size-content
 
 This plugin also generates the following `h-*` and `w-*` utilities to animate the size of the content when it opens/closes.
 
@@ -171,7 +171,7 @@ This plugin also generates the following `h-*` and `w-*` utilities to animate th
 }
 
 .w-radix-accordion {
-  widht: var(--radix-accordion-content-widht);
+  width: var(--radix-accordion-content-width);
 }
 
 .h-radix-collapsible {
@@ -179,8 +179,37 @@ This plugin also generates the following `h-*` and `w-*` utilities to animate th
 }
 
 .w-radix-collapsible {
-  widht: var(--radix-collapsible-content-widht);
+  width: var(--radix-collapsible-content-width);
 }
+```
+
+## Example
+
+For example used `<Transition/>` component from `@headlessui/react`
+
+```tsx
+...
+<Accordion.Content forceMount className="overflow-hidden">
+  <Transition
+    show={currentItem === "item-1"}
+    enter="ease-out duration-300"
+    enterFrom="h-0"
+    enterTo="h-radix-accordion"
+    leave="ease-in duration-300"
+    leaveFrom="h-radix-accordion"
+    leaveTo="h-0"
+  >
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit.
+      Voluptatum ullam, ratione veniam voluptate nobis sunt laboriosam
+      aperiam harum fugit corrupti alias magnam officiis nihil minima
+      eum excepturi natus similique? Cupiditate reprehenderit, hic sequi
+      modi nemo odit esse quas adipisci perferendis beatae deserunt
+      ducimus itaque molestias quibusdam porro assumenda laudantium id!
+    </p>
+  </Transition>
+</Accordion.Content>
+...
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 [![tailwindcss v3 ready](https://img.shields.io/badge/tailwindcss-v3%20ready-0F172A?logo=tailwindcss&style=flat&labelColor=38bdf8&logoColor=ffffff)](https://tailwindcss.com)
 [![npm version](https://img.shields.io/npm/v/tailwindcss-radix.svg)](https://www.npmjs.com/package/tailwindcss-radix)
 [![npm downloads](https://img.shields.io/npm/dm/tailwindcss-radix.svg)](https://www.npmjs.com/package/tailwindcss-radix)
+
 # TailwindCSS Radix
 
 Utilities and variants for styling Radix state
+
 ## Installation
 
 ### yarn
@@ -33,8 +35,8 @@ module.exports = {
     // ...
   },
   plugins: [
-      // Initialize with default values (see options below)
-      require("tailwindcss-radix")(),
+    // Initialize with default values (see options below)
+    require("tailwindcss-radix")(),
   ],
 };
 ```
@@ -47,8 +49,8 @@ require("tailwindcss-radix")({
   variantPrefix: "rdx",
   // Default: `false`
   // Cannot be enabled in combination with `variantPrefix: ""`
-  skipAttributeNames: false
-})
+  skipAttributeNames: false,
+});
 ```
 
 ```ts
@@ -84,7 +86,7 @@ const App = () => {
       <DropdownMenu.Content>
         <DropdownMenu.Item>Item</DropdownMenu.Item>
       </DropdownMenu.Content>
-    </DropdownMenu.Root>  
+    </DropdownMenu.Root>
   );
 };
 
@@ -126,7 +128,7 @@ const App = () => {
         </Accordion.Header>
         <Accordion.Content>Content 2</Accordion.Content>
       </Accordion.Item>
-    </Accordion.Root> 
+    </Accordion.Root>
   );
 };
 
@@ -139,23 +141,45 @@ This plugin also generates the following `origin-*` utilities to transform from 
 
 ```css
 .origin-radix-dropdown-menu {
-    transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
 }
 
 .origin-radix-hover-card {
-    transform-origin: var(--radix-hover-card-content-transform-origin);
+  transform-origin: var(--radix-hover-card-content-transform-origin);
 }
 
 .origin-radix-context-menu {
-    transform-origin: var(--radix-context-menu-content-transform-origin);
+  transform-origin: var(--radix-context-menu-content-transform-origin);
 }
 
 .origin-radix-popover {
-    transform-origin: var(--radix-popover-content-transform-origin);
+  transform-origin: var(--radix-popover-content-transform-origin);
 }
 
 .origin-radix-tooltip {
-    transform-origin: var(--radix-tooltip-content-transform-origin);
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+}
+```
+
+### Animating content size
+
+This plugin also generates the following `h-*` and `w-*` utilities to animate the size of the content when it opens/closes.
+
+```css
+.h-radix-accordion {
+  height: var(--radix-accordion-content-height);
+}
+
+.w-radix-accordion {
+  widht: var(--radix-accordion-content-widht);
+}
+
+.h-radix-collapsible {
+  height: var(--radix-collapsible-content-height);
+}
+
+.w-radix-collapsible {
+  widht: var(--radix-collapsible-content-widht);
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,12 +84,12 @@ export = plugin.withOptions((options) => ({ addUtilities, addVariant, e }) => {
   // Adds the following height utilities
   // `--radix-accordion-content-height`,
   // `--radix-collapsible-content-height`,
-  const heights = ["accordion", "collapsible"];
+  const componentContentHeights = ["accordion", "collapsible"];
 
-  heights.forEach((height) => {
+  componentContentHeights.forEach((component) => {
     addUtilities({
-      [`.h-${variantPrefix}${height}`]: {
-        height: `var(--radix-${height}-content-height)`,
+      [`.h-${variantPrefix}${component}`]: {
+        height: `var(--radix-${component}-content-height)`,
       },
     });
   });
@@ -97,12 +97,12 @@ export = plugin.withOptions((options) => ({ addUtilities, addVariant, e }) => {
   // Adds the following width utilities
   // `--radix-accordion-content-width`,
   // `--radix-collapsible-content-width`,
-  const widths = ["accordion", "collapsible"];
+  const componentContentWidths = ["accordion", "collapsible"];
 
-  widths.forEach((width) => {
+  componentContentWidths.forEach((component) => {
     addUtilities({
-      [`.w-${variantPrefix}${width}`]: {
-        width: `var(--radix-${width}-content-width)`,
+      [`.w-${variantPrefix}${component}`]: {
+        width: `var(--radix-${component}-content-width)`,
       },
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
 import plugin from "tailwindcss/plugin";
 
 const dataAttributes = {
-  state: ["open", "closed", "active", "inactive", "on", "off", "checked", "unchecked"],
+  state: [
+    "open",
+    "closed",
+    "active",
+    "inactive",
+    "on",
+    "off",
+    "checked",
+    "unchecked",
+  ],
   side: ["top", "bottom", "left", "right"],
   orientation: ["horizontal", "vertical"],
 };
@@ -70,5 +79,31 @@ export = plugin.withOptions((options) => ({ addUtilities, addVariant, e }) => {
         });
       }
     );
+  });
+
+  // Adds the following height utilities
+  // `--radix-accordion-content-height`,
+  // `--radix-collapsible-content-height`,
+  const heights = ["accordion", "collapsible"];
+
+  heights.forEach((height) => {
+    addUtilities({
+      [`.h-${variantPrefix}${height}`]: {
+        height: `var(--radix-${height}-content-height)`,
+      },
+    });
+  });
+
+  // Adds the following width utilities
+  // `--radix-accordion-content-width`,
+  // `--radix-collapsible-content-width`,
+  const widths = ["accordion", "collapsible"];
+
+  widths.forEach((width) => {
+    addUtilities({
+      [`.w-${variantPrefix}${width}`]: {
+        width: `var(--radix-${width}-content-width)`,
+      },
+    });
   });
 });


### PR DESCRIPTION
### Animating content size
Use the `--radix-accordion-content-width` and/or ` --radix-accordion-content-height` CSS variables to animate the size of the content when it opens/closes.

```tsx
<Accordion.Content forceMount className="overflow-hidden">
  <Transition
    show={currentItem === "item-1"}
    enter="ease-out duration-300"
    enterFrom="h-0"
    enterTo="h-radix-accordion"
    leave="ease-in duration-300"
    leaveFrom="h-radix-accordion"
    leaveTo="h-0"
  >
    <p>
      Lorem ipsum dolor sit amet consectetur adipisicing elit.
      Voluptatum ullam, ratione veniam voluptate nobis sunt laboriosam
      aperiam harum fugit corrupti alias magnam officiis nihil minima
      eum excepturi natus similique? Cupiditate reprehenderit, hic sequi
      modi nemo odit esse quas adipisci perferendis beatae deserunt
      ducimus itaque molestias quibusdam porro assumenda laudantium id!
    </p>
  </Transition>
</Accordion.Content>
```

[Accordion docs](https://www.radix-ui.com/docs/primitives/components/accordion#animating-content-size)
[Collapsible docs](https://www.radix-ui.com/docs/primitives/components/collapsible#animating-content-size)