### PR TITLE
refactor: use native 1/2 tailwind class

### DIFF
--- a/demo/components/alert-dialog.tsx
+++ b/demo/components/alert-dialog.tsx
@@ -44,7 +44,7 @@ const AlertDialog = (props: AlertDialogProps) => {
               className={clsx(
                 "fixed z-50",
                 "w-[95vw] max-w-md rounded-lg p-4 md:w-full",
-                "top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]",
+                "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
                 "bg-white dark:bg-gray-800",
                 "focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75"
               )}

--- a/demo/components/dialog.tsx
+++ b/demo/components/dialog.tsx
@@ -45,7 +45,7 @@ const Dialog = (props: DialogProps) => {
               className={clsx(
                 "fixed z-50",
                 "w-[95vw] max-w-md rounded-lg p-4 md:w-full",
-                "top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]",
+                "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
                 "bg-white dark:bg-gray-800",
                 "focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75"
               )}


### PR DESCRIPTION
This PR replaces `*-[50%]` arbitrary classes with Tailwind native `*-1/2` classes.